### PR TITLE
Fixed issue in comment formatting.

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -215,6 +215,7 @@ function inTypicalSub(submission) {
 }
 
 var convert = function(convert){
+	convert = convert.replace('href="/r/', 'href="http://reddit.com/r/');
 	return $("<span />", { html: convert }).text();
 };
 


### PR DESCRIPTION
When comments contianed links in the format /r/foobar, they redirected to xkcd.com/r/foobar instead of reddit.com/r/foobar. Just add a simple replace and now it seems to work.
